### PR TITLE
Add BlueOak-1.0.0 to allowed licenses

### DIFF
--- a/allowed-licenses.txt
+++ b/allowed-licenses.txt
@@ -17,3 +17,4 @@ Python-2.0
 Unlicense
 WTFPL
 Zlib
+BlueOak-1.0.0


### PR DESCRIPTION
Add https://blueoakcouncil.org/license/1.0.0 to the list of permissive licenses