### PR TITLE
Bug/fix symlink already exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 # TODO: Node alpine
 FROM node:20.3-slim
 
-# For some reason, the executable for that package stopped working - so we'll manually link it
-RUN npm install -g license-checker-rseidelsohn && \
-    ln -s "$(npm root -g)/license-checker-rseidelsohn/bin/license-checker-rseidelsohn.js" /usr/local/bin/license-checker-rseidelsohn
+RUN npm install -g license-checker-rseidelsohn
+
+# Create symlink if it doesn't exist
+RUN if [ ! -e /usr/local/bin/license-checker-rseidelsohn ]; then \
+        ln -s "$(npm root -g)/license-checker-rseidelsohn/bin/license-checker-rseidelsohn.js" /usr/local/bin/license-checker-rseidelsohn; \
+    fi
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY allowed-licenses.txt /allowed-licenses.txt


### PR DESCRIPTION
## Spec:
* Docker build started failing with the following error
```bash
3.130 npm notice Run `npm install -g npm@10.8.3` to update!
3.130 npm notice
3.642 ln: failed to create symbolic link '/usr/local/bin/license-checker-rseidelsohn': File exists
------
Dockerfile:5
--------------------
   4 |     # For some reason, the executable for that package stopped working - so we'll manually link it
   5 | >>> RUN npm install -g license-checker-rseidelsohn && \
   6 | >>>     ln -s "$(npm root -g)/license-checker-rseidelsohn/bin/license-checker-rseidelsohn.js" /usr/local/bin/license-checker-rseidelsohn
   7 |
--------------------
```

Because the library symlink creation was fixed. We need to take into account both cases.